### PR TITLE
Fix/manual navigation

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -45,5 +45,6 @@ site.use(postcss());
 site.ignore("index.html");
 site.copy("styles.css");
 site.copy("assets");
+site.copy("js");
 
 export default site;

--- a/src/_components/ManualSectionDropdown.jsx
+++ b/src/_components/ManualSectionDropdown.jsx
@@ -55,8 +55,13 @@ export default function ManualSectionDropdown({ search }) {
       ))}
 
       {/* Desktop Table of Contents */}
-      <div className="flex flex-col md:flex-row flex-wrap rounded relative md:sticky md:top-0 md:z-20">
+      <div className="max-md:hidden flex flex-wrap rounded relative sticky top-0 z-20">
         <NavigationLinks groupedSections={groupedSections} />
+      </div>
+
+      {/* Mobile Table of Contents */}
+      <div className="flex md:hidden text-xs rounded relative sticky top-0 z-20">
+        <NavigationLinks groupedSections={groupedSections} mobile={true} />
       </div>
 
       {/* Content of each individual section */}
@@ -104,7 +109,7 @@ export default function ManualSectionDropdown({ search }) {
   );
 }
 
-function NavigationLinks({ groupedSections }) {
+function NavigationLinks({ groupedSections, mobile = false }) {
   return Object.entries(
     groupedSections, // Group sections by chapter
   ).map(([chapter, chapterSections]) => (
@@ -112,17 +117,23 @@ function NavigationLinks({ groupedSections }) {
       className="relative group focus-within:block"
       key={`chapter-${chapter}`}
     >
-      <label className="cursor-pointer block w-full bg-background-grey px-4 md:px-12 py-3 font-bold text-primary group-hover:bg-green group-hover:text-white">
-        {Number(chapter) === 0 ? "Introduction" : `Chapter ${chapter}`}
+      <label className="cursor-pointer block w-full bg-background-grey px-4 sm:px-6 lg:px-12 py-3 font-bold text-primary group-hover:bg-green group-hover:text-white">
+        {mobile
+          ? Number(chapter) === 0
+            ? "Intro"
+            : `Ch.${chapter}`
+          : Number(chapter) === 0
+            ? "Introduction"
+            : `Chapter ${chapter}`}
       </label>
-      <div className="absolute top-full left-0 w-full max-w-screen hidden group-hover:flex group-focus-within:flex flex-col bg-white rounded shadow-lg z-10 max-h-[75vh] overflow-y-auto">
+      <div className="absolute top-full left-0 w-full max-w-screen hidden group-hover:flex group-focus-within:flex flex-col bg-white rounded shadow-lg z-10 max-h-[75vh] overflow-y-auto text-left">
         {chapterSections.map((section) => (
           <label
             htmlFor={section.id}
             key={`label-${section.id}`}
             className="cursor-pointer px-6 py-3 hover:bg-green hover:text-white text-primary manual-label"
           >
-            {section.title}
+            {mobile ? `Sec. ${section.section}` : section.title}
           </label>
         ))}
       </div>

--- a/src/_components/ManualSectionDropdown.jsx
+++ b/src/_components/ManualSectionDropdown.jsx
@@ -15,6 +15,7 @@ export default function ManualSectionDropdown({ search }) {
 
   return (
     <section className="px-6 py-12 max-w-7xl mx-auto">
+      <div id="manual-top" />
       {/* Inputs for each section */}
       {sections.map((section) => (
         <input
@@ -54,7 +55,7 @@ export default function ManualSectionDropdown({ search }) {
                   <label
                     htmlFor={section.id}
                     key={`label-${section.id}`}
-                    className="cursor-pointer px-6 py-3 hover:bg-green hover:text-white text-primary sm:whitespace-nowrap"
+                    className="cursor-pointer px-6 py-3 hover:bg-green hover:text-white text-primary sm:whitespace-nowrap manual-label"
                   >
                     {section.title}
                   </label>

--- a/src/_components/ManualSectionDropdown.jsx
+++ b/src/_components/ManualSectionDropdown.jsx
@@ -18,6 +18,12 @@ export default function ManualSectionDropdown({ search }) {
       return a.section - b.section;
     }); // Sort by chapter, then by section within chapter
 
+  const groupedSections = sections.reduce((acc, section) => {
+    acc[section.chapter] = acc[section.chapter] || [];
+    acc[section.chapter].push(section);
+    return acc;
+  }, {});
+
   const adjacents = sections.map((section, index) => {
     const prev = index > 0 ? sections[index - 1] : null;
     const next = index < sections.length - 1 ? sections[index + 1] : null;
@@ -48,35 +54,42 @@ export default function ManualSectionDropdown({ search }) {
         />
       ))}
 
-      {/* Labels for inputs and styling for manual dropdown */}
-      <div className="flex flex-wrap md:flex-row flex-col rounded relative sticky top-0 z-20">
-        {Object.entries(
-          sections.reduce((acc, section) => {
-            acc[section.chapter] = acc[section.chapter] || [];
-            acc[section.chapter].push(section);
-            return acc;
-          }, {}),
-        ).map(([chapter, chapterSections]) => (
-          <div
-            className="relative group focus-within:block"
-            key={`chapter-${chapter}`}
+      {/* Mobile Table of Contents Dropdown */}
+      <input
+        type="checkbox"
+        id="accordianMenuManual"
+        title="Mobile Menu"
+        className="hidden peer"
+      />
+      <div className="lg:hidden">
+        <label
+          htmlFor="accordianMenuManual"
+          className="flex cursor-pointer label"
+        >
+          Table of Contents
+          <svg
+            className="w-10 h-10 text-black"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <label className="cursor-pointer block w-full bg-background-grey px-8 py-3 font-bold text-primary group-hover:bg-green group-hover:text-white">
-              {Number(chapter) === 0 ? "Introduction" : `Chapter ${chapter}`}
-            </label>
-            <div className="absolute top-full left-0 w-full md:min-w-max hidden group-hover:flex group-focus-within:flex flex-col bg-white rounded shadow-lg z-10">
-              {chapterSections.map((section) => (
-                <label
-                  htmlFor={section.id}
-                  key={`label-${section.id}`}
-                  className="cursor-pointer px-6 py-3 hover:bg-green hover:text-white text-primary sm:whitespace-nowrap manual-label"
-                >
-                  {section.title}
-                </label>
-              ))}
-            </div>
-          </div>
-        ))}
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M4 6 h16 M4 12 h16 M4 18 h16"
+            ></path>
+          </svg>
+        </label>
+      </div>
+      {/* Mobile Table of Contents */}
+      <div className="lg:hidden overflow-hidden peer-checked:max-h-screen max-h-0 flex flex-col transition-all duration-300 pb-3">
+        <NavigationLinks groupedSections={groupedSections} />
+      </div>
+      {/* Desktop Table of Contents */}
+      <div className="max-lg:hidden flex flex-wrap rounded relative sticky top-0 z-20">
+        <NavigationLinks groupedSections={groupedSections} />
       </div>
 
       {/* Content of each individual section */}
@@ -104,7 +117,7 @@ export default function ManualSectionDropdown({ search }) {
               className="cursor-pointer px-6 py-3 hover:text-green text-primary rounded w-1/2 manual-label"
             >
               ← Previous -{" "}
-              {`${adjacent.prev.chapter !== 0 ? `Chapter ${adjacent.prev.chapter}` : ""}`}{" "}
+              {`${adjacent.prev.chapter !== 0 && adjacent.prev.section !== 0 ? `Chapter ${adjacent.prev.chapter}` : ""}`}{" "}
               {adjacent.prev.title}
             </label>
           )}
@@ -113,8 +126,8 @@ export default function ManualSectionDropdown({ search }) {
               htmlFor={adjacent.next.id}
               className="cursor-pointer px-6 py-3 hover:text-green text-primary rounded w-1/2 manual-label"
             >
-              Next - Chapter{" "}
-              {`${adjacent.next.chapter !== 0 ? `Chapter ${adjacent.next.chapter}` : ""}`}
+              Next -{" "}
+              {`${adjacent.next.chapter !== 0 && adjacent.next.section !== 0 ? `Chapter ${adjacent.next.chapter}` : ""}`}
               , {adjacent.next.title} →
             </label>
           )}
@@ -122,4 +135,30 @@ export default function ManualSectionDropdown({ search }) {
       ))}
     </section>
   );
+}
+
+function NavigationLinks({ groupedSections }) {
+  return Object.entries(
+    groupedSections, // Group sections by chapter
+  ).map(([chapter, chapterSections]) => (
+    <div
+      className="relative group focus-within:block"
+      key={`chapter-${chapter}`}
+    >
+      <label className="cursor-pointer block w-full bg-background-grey px-8 py-3 font-bold text-primary group-hover:bg-green group-hover:text-white">
+        {Number(chapter) === 0 ? "Introduction" : `Chapter ${chapter}`}
+      </label>
+      <div className="w-full md:min-w-max hidden group-hover:flex group-focus-within:flex flex-col bg-white rounded shadow-lg z-10">
+        {chapterSections.map((section) => (
+          <label
+            htmlFor={section.id}
+            key={`label-${section.id}`}
+            className="cursor-pointer px-6 py-3 hover:bg-green hover:text-white text-primary sm:whitespace-nowrap manual-label"
+          >
+            {section.title}
+          </label>
+        ))}
+      </div>
+    </div>
+  ));
 }

--- a/src/_components/ManualSectionDropdown.jsx
+++ b/src/_components/ManualSectionDropdown.jsx
@@ -11,7 +11,22 @@ export default function ManualSectionDropdown({ search }) {
       chapter: section.chapter,
       body: section.content, // markdown content
     }))
-    .sort((a, b) => a.section - b.section); // Sort by section number i.e 1-4
+    .sort((a, b) => {
+      if (a.chapter !== b.chapter) {
+        return a.chapter - b.chapter;
+      }
+      return a.section - b.section;
+    }); // Sort by chapter, then by section within chapter
+
+  const adjacents = sections.map((section, index) => {
+    const prev = index > 0 ? sections[index - 1] : null;
+    const next = index < sections.length - 1 ? sections[index + 1] : null;
+    return {
+      id: section.id,
+      prev: prev ? { id: prev.id, title: prev.title } : null,
+      next: next ? { id: next.id, title: next.title } : null,
+    };
+  });
 
   return (
     <section className="px-6 py-12 max-w-7xl mx-auto">
@@ -64,6 +79,31 @@ export default function ManualSectionDropdown({ search }) {
           </div>
         ))}
       </div>
+
+      {/* Adjacents for each section */}
+      {adjacents.map((adjacent) => (
+        <div
+          key={`nav-${adjacent.id}`}
+          className={`hidden peer-checked/${adjacent.id}:flex justify-between mt-4`}
+        >
+          {adjacent.prev && (
+            <label
+              htmlFor={adjacent.prev.id}
+              className="cursor-pointer px-6 py-3 hover:text-green text-primary rounded"
+            >
+              ← Previous: {adjacent.prev.title}
+            </label>
+          )}
+          {adjacent.next && (
+            <label
+              htmlFor={adjacent.next.id}
+              className="cursor-pointer px-6 py-3 hover:text-green text-primary rounded"
+            >
+              Next: {adjacent.next.title} →
+            </label>
+          )}
+        </div>
+      ))}
 
       {/* Content of each individual section */}
       {sections.map((section) => (

--- a/src/_components/ManualSectionDropdown.jsx
+++ b/src/_components/ManualSectionDropdown.jsx
@@ -29,7 +29,7 @@ export default function ManualSectionDropdown({ search }) {
       ))}
 
       {/* Labels for inputs and styling for manual dropdown */}
-      <div className="flex flex-wrap md:flex-row flex-col rounded relative">
+      <div className="flex flex-wrap md:flex-row flex-col rounded relative sticky top-0 z-20">
         {Object.entries(
           sections.reduce((acc, section) => {
             acc[section.chapter] = acc[section.chapter] || [];

--- a/src/_components/ManualSectionDropdown.jsx
+++ b/src/_components/ManualSectionDropdown.jsx
@@ -131,9 +131,9 @@ function NavigationLinks({ groupedSections, mobile = false }) {
           <label
             htmlFor={section.id}
             key={`label-${section.id}`}
-            className="cursor-pointer px-6 py-3 hover:bg-green hover:text-white text-primary manual-label"
+            className="cursor-pointer px-2 sm:px-6 py-3 hover:bg-green hover:text-white text-primary manual-label"
           >
-            {mobile ? `Sec. ${section.section}` : section.title}
+            {mobile ? `Sec.${section.section}` : section.title}
           </label>
         ))}
       </div>

--- a/src/_components/ManualSectionDropdown.jsx
+++ b/src/_components/ManualSectionDropdown.jsx
@@ -61,24 +61,19 @@ export default function ManualSectionDropdown({ search }) {
             className="relative group focus-within:block"
             key={`chapter-${chapter}`}
           >
-            <label
-              htmlFor={`${chapterSections[0].id}`}
-              className="cursor-pointer block w-full bg-background-grey px-8 py-3 font-bold text-primary group-hover:bg-green group-hover:text-white"
-            >
+            <label className="cursor-pointer block w-full bg-background-grey px-8 py-3 font-bold text-primary group-hover:bg-green group-hover:text-white">
               {Number(chapter) === 0 ? "Introduction" : `Chapter ${chapter}`}
             </label>
             <div className="absolute top-full left-0 w-full md:min-w-max hidden group-hover:flex group-focus-within:flex flex-col bg-white rounded shadow-lg z-10">
-              {chapterSections
-                .filter((section) => section.section !== 0) // Only include sections that are not 0
-                .map((section) => (
-                  <label
-                    htmlFor={section.id}
-                    key={`label-${section.id}`}
-                    className="cursor-pointer px-6 py-3 hover:bg-green hover:text-white text-primary sm:whitespace-nowrap manual-label"
-                  >
-                    {section.title}
-                  </label>
-                ))}
+              {chapterSections.map((section) => (
+                <label
+                  htmlFor={section.id}
+                  key={`label-${section.id}`}
+                  className="cursor-pointer px-6 py-3 hover:bg-green hover:text-white text-primary sm:whitespace-nowrap manual-label"
+                >
+                  {section.title}
+                </label>
+              ))}
             </div>
           </div>
         ))}

--- a/src/_components/ManualSectionDropdown.jsx
+++ b/src/_components/ManualSectionDropdown.jsx
@@ -23,8 +23,12 @@ export default function ManualSectionDropdown({ search }) {
     const next = index < sections.length - 1 ? sections[index + 1] : null;
     return {
       id: section.id,
-      prev: prev ? { id: prev.id, title: prev.title } : null,
-      next: next ? { id: next.id, title: next.title } : null,
+      prev: prev
+        ? { id: prev.id, title: prev.title, chapter: prev.chapter }
+        : null,
+      next: next
+        ? { id: next.id, title: next.title, chapter: next.chapter }
+        : null,
     };
   });
 
@@ -80,31 +84,6 @@ export default function ManualSectionDropdown({ search }) {
         ))}
       </div>
 
-      {/* Adjacents for each section */}
-      {adjacents.map((adjacent) => (
-        <div
-          key={`nav-${adjacent.id}`}
-          className={`hidden peer-checked/${adjacent.id}:flex justify-between mt-4`}
-        >
-          {adjacent.prev && (
-            <label
-              htmlFor={adjacent.prev.id}
-              className="cursor-pointer px-6 py-3 hover:text-green text-primary rounded"
-            >
-              ← Previous: {adjacent.prev.title}
-            </label>
-          )}
-          {adjacent.next && (
-            <label
-              htmlFor={adjacent.next.id}
-              className="cursor-pointer px-6 py-3 hover:text-green text-primary rounded"
-            >
-              Next: {adjacent.next.title} →
-            </label>
-          )}
-        </div>
-      ))}
-
       {/* Content of each individual section */}
       {sections.map((section) => (
         <section
@@ -116,6 +95,35 @@ export default function ManualSectionDropdown({ search }) {
             {section.body}
           </ReactMarkdown>
         </section>
+      ))}
+
+      {/* Adjacents for each section */}
+      {adjacents.map((adjacent) => (
+        <div
+          key={`nav-${adjacent.id}`}
+          className={`hidden peer-checked/${adjacent.id}:flex justify-between mt-4`}
+        >
+          {adjacent.prev && (
+            <label
+              htmlFor={adjacent.prev.id}
+              className="cursor-pointer px-6 py-3 hover:text-green text-primary rounded w-1/2 manual-label"
+            >
+              ← Previous -{" "}
+              {`${adjacent.prev.chapter !== 0 ? `Chapter ${adjacent.prev.chapter}` : ""}`}{" "}
+              {adjacent.prev.title}
+            </label>
+          )}
+          {adjacent.next && (
+            <label
+              htmlFor={adjacent.next.id}
+              className="cursor-pointer px-6 py-3 hover:text-green text-primary rounded w-1/2 manual-label"
+            >
+              Next - Chapter{" "}
+              {`${adjacent.next.chapter !== 0 ? `Chapter ${adjacent.next.chapter}` : ""}`}
+              , {adjacent.next.title} →
+            </label>
+          )}
+        </div>
       ))}
     </section>
   );

--- a/src/_components/ManualSectionDropdown.jsx
+++ b/src/_components/ManualSectionDropdown.jsx
@@ -54,41 +54,8 @@ export default function ManualSectionDropdown({ search }) {
         />
       ))}
 
-      {/* Mobile Table of Contents Dropdown */}
-      <input
-        type="checkbox"
-        id="accordianMenuManual"
-        title="Mobile Menu"
-        className="hidden peer"
-      />
-      <div className="lg:hidden">
-        <label
-          htmlFor="accordianMenuManual"
-          className="flex cursor-pointer label"
-        >
-          Table of Contents
-          <svg
-            className="w-10 h-10 text-black"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              d="M4 6 h16 M4 12 h16 M4 18 h16"
-            ></path>
-          </svg>
-        </label>
-      </div>
-      {/* Mobile Table of Contents */}
-      <div className="lg:hidden overflow-hidden peer-checked:max-h-screen max-h-0 flex flex-col transition-all duration-300 pb-3">
-        <NavigationLinks groupedSections={groupedSections} />
-      </div>
       {/* Desktop Table of Contents */}
-      <div className="max-lg:hidden flex flex-wrap rounded relative sticky top-0 z-20">
+      <div className="flex flex-col md:flex-row flex-wrap rounded relative md:sticky md:top-0 md:z-20">
         <NavigationLinks groupedSections={groupedSections} />
       </div>
 
@@ -145,15 +112,15 @@ function NavigationLinks({ groupedSections }) {
       className="relative group focus-within:block"
       key={`chapter-${chapter}`}
     >
-      <label className="cursor-pointer block w-full bg-background-grey px-8 py-3 font-bold text-primary group-hover:bg-green group-hover:text-white">
+      <label className="cursor-pointer block w-full bg-background-grey px-4 md:px-12 py-3 font-bold text-primary group-hover:bg-green group-hover:text-white">
         {Number(chapter) === 0 ? "Introduction" : `Chapter ${chapter}`}
       </label>
-      <div className="w-full md:min-w-max hidden group-hover:flex group-focus-within:flex flex-col bg-white rounded shadow-lg z-10">
+      <div className="absolute top-full left-0 w-full max-w-screen hidden group-hover:flex group-focus-within:flex flex-col bg-white rounded shadow-lg z-10 max-h-[75vh] overflow-y-auto">
         {chapterSections.map((section) => (
           <label
             htmlFor={section.id}
             key={`label-${section.id}`}
-            className="cursor-pointer px-6 py-3 hover:bg-green hover:text-white text-primary sm:whitespace-nowrap manual-label"
+            className="cursor-pointer px-6 py-3 hover:bg-green hover:text-white text-primary manual-label"
           >
             {section.title}
           </label>

--- a/src/_includes/_layouts/Manual.jsx
+++ b/src/_includes/_layouts/Manual.jsx
@@ -6,6 +6,7 @@ export default function Manual({ title, comp, search }) {
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>{title}</title>
         <link rel="stylesheet" href="/css/styles.css" />
+        <script src="/js/scroll.js" />
         {/* Google tag (gtag.js) */}
         <script
           async

--- a/src/js/scroll.js
+++ b/src/js/scroll.js
@@ -1,0 +1,11 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const labels = document.querySelectorAll(".manual-label");
+  labels.forEach((label) => {
+    label.addEventListener("click", () => {
+      const topEl = document.getElementById("manual-top");
+      if (topEl) {
+        topEl.scrollIntoView({ behavior: "smooth" });
+      }
+    });
+  });
+});

--- a/src/manual/chapter-1/ch1.md
+++ b/src/manual/chapter-1/ch1.md
@@ -1,7 +1,7 @@
 ---
 chapter: 1
 section: 0
-title: "Chapter One"
+title: "Chapter One: Rights of Insured Patients"
 id: ch1-s0
 ---
 

--- a/src/manual/chapter-2/ch2.md
+++ b/src/manual/chapter-2/ch2.md
@@ -1,7 +1,7 @@
 ---
 chapter: 2
 section: 0
-title: "Chapter Two"
+title: "Chapter Two: Rights of Uninsured Patients"
 id: ch2-s0
 ---
 

--- a/src/manual/chapter-3/ch3.md
+++ b/src/manual/chapter-3/ch3.md
@@ -1,7 +1,7 @@
 ---
 chapter: 3
 section: 0
-title: "Chapter Three"
+title: "Chapter Three: What to Do When You Receive a Bill"
 id: ch3-s0
 ---
 

--- a/src/manual/chapter-4/ch4-s3.md
+++ b/src/manual/chapter-4/ch4-s3.md
@@ -5,7 +5,7 @@ title: "Section 3: How to Deal with a Debt Collection Lawsuit"
 id: ch4-s3
 ---
 
-## Section 3: How to Deal with a Debt Collection Lawsuit
+# Section 3: How to Deal with a Debt Collection Lawsuit
 
 At some point, you might receive, either in person or by mail, notification that you have been sued over a medical debt. What we said about the debt collection process is even more true when it comes to a lawsuit: **DO NOT IGNORE IT.** It will not go away on its own.
 

--- a/src/manual/chapter-4/ch4-s4.md
+++ b/src/manual/chapter-4/ch4-s4.md
@@ -5,7 +5,7 @@ title: "Section 4: Your Rights After a Judgment Against You"
 id: ch4-s4
 ---
 
-## Section 4: Your Rights After a Judgment Against You
+# Section 4: Your Rights After a Judgment Against You
 
 If you end up with a Judgment against you, you either went to trial and lost or you lost without trial on a Motion for Summary Judgment. In either case, you can file an “Appeal” if you think the court got it wrong. The other possibility is that the court issued a “Default Judgment” against you because you did not file an Answer or you did, but maybe you did not show up for trial, or missed some other deadline and the Plaintiff won by “default,” equivalent to a forfeit in sports.
 

--- a/src/manual/chapter-4/ch4.md
+++ b/src/manual/chapter-4/ch4.md
@@ -1,7 +1,7 @@
 ---
 chapter: 4
 section: 0
-title: "Chapter Four"
+title: "Chapter Four: Understanding the Collection Process"
 id: ch4-s0
 ---
 

--- a/src/manual/introduction.md
+++ b/src/manual/introduction.md
@@ -1,7 +1,7 @@
 ---
 chapter: 0
 section: 0
-title: "Introduction"
+title: "Introduction: Understanding Medical Debt Relief in New Jersey"
 id: introduction
 ---
 


### PR DESCRIPTION
Issues #70 #73 

- Made table of contents navigation stick to top of screen as users scroll
- Added previous and next buttons to make it easier to switch between sections
- Added javascript to scroll back to the top when a user switches section
- Patched inconsistent dropdown on mobile

Sticky Nav Desktop:
![image](https://github.com/user-attachments/assets/f9832fe5-1e40-4b5c-9ff1-17dd38f1819a)

Sticky Nav Manual:
![image](https://github.com/user-attachments/assets/5f552e54-6e97-4184-a99a-7520526d277d)

Shorted to "Ch1" and "Sec.1" on mobile otherwise the section titles covered too much of the screen. To see the added scroll javascript behavior, pick a long section in the manual, scroll until the header is out of sight, and than change sections. You should see the window scroll to the top of the new section.

